### PR TITLE
Add Scoop CLI installer to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,13 @@ Signatures for PE-bear:
 
 📦 ⚙️ Download the latest [release](https://github.com/hasherezade/pe-bear/releases).
 
+
+### Windows Packaging
 ![](https://community.chocolatey.org/favicon.ico) Available also via [Chocolatey](https://community.chocolatey.org/packages/pebear)
+
+![](https://avatars.githubusercontent.com/u/16618068?s=15) Available also via [Scoop](https://scoop.sh/#/apps?q=pe-bear)
+
+### Test Builds
 
 🧪 Fresh **test builds** (ahead of the official release) can be downloaded from the [AppVeyor build server](https://ci.appveyor.com/project/hasherezade/pe-bear). They are created on each commit to the `main` branch. You can download them by clicking on the build version, then choosing the tab `Artifacts`. WARNING: those builds may be unstable.
 


### PR DESCRIPTION
I updated PE-Bear in https://github.com/ScoopInstaller/Extras/pull/12237 so it is installable via Scoop again, as well. Gave the builds some headlines as well.