### PR TITLE
[BUGFIX] Limited export of MIME types from desktop file to PE files only

### DIFF
--- a/xdg/launcher.desktop.in
+++ b/xdg/launcher.desktop.in
@@ -7,5 +7,5 @@ Comment=Portable Executable reversing tool with a friendly GUI
 Icon=@SCHEME_NAME@
 Exec=@PROJECT_NAME@ %F
 Terminal=false
-MimeType=application/octet-stream;application/x-msdownload;
+MimeType=application/vnd.microsoft.portable-executable;application/x-msdownload;
 


### PR DESCRIPTION
Limited export of MIME types from desktop file to PE files.

Current `application/octet-stream` is too wide and will register PE-Bear with all partially downloaded and even unknown file types.